### PR TITLE
Fixing filter functions signature and behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [0.8.1] - 2025-02-15
+## [1.0.0] - 2025-02-15
 ### Fixed
-- Function signature of `filter` and `filterNot` changed to return an Error (or an instance deriving from it)
+- Function signature of `filter` and `filterNot` changed to return an Error (or an instance deriving from it) instead of nothing.
 
 ## [0.8.0] - 2025-02-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.8.1] - 2025-02-15
+### Fixed
+- Function signature of `filter` and `filterNot` changed to return an Error (or an instance deriving from it)
+
 ## [0.8.0] - 2025-02-14
 ### Added
 - `andFinally` method for running code independent on the state

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "try-typescript",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "description": "This repository implements a Try class inspired by the Vavr library in Java. The Try class is a functional programming construct for handling computations that may succeed or fail. It encapsulates exceptions and streamlines error handling, reducing boilerplate code and enhancing code readability. ",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "try-typescript",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "This repository implements a Try class inspired by the Vavr library in Java. The Try class is a functional programming construct for handling computations that may succeed or fail. It encapsulates exceptions and streamlines error handling, reducing boilerplate code and enhancing code readability. ",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/Try.ts
+++ b/src/lib/Try.ts
@@ -114,7 +114,7 @@ export class Try<T> {
                 else if(executionElement.name === TryFunctions.FILTER){
                     if(this.isSuccess()){
                         if(await executionElement.functionData.func(this.value)){
-                            await executionElement.functionData.fallbackFunction!(this.value);
+                            throw await executionElement.functionData.fallbackFunction!(this.value);
                         }
                     }
                 }
@@ -122,7 +122,7 @@ export class Try<T> {
                 else if(executionElement.name === TryFunctions.FILTERNOT){
                     if(this.isSuccess()){
                         if(!await executionElement.functionData.func(this.value)){
-                            await executionElement.functionData.fallbackFunction!(this.value);
+                            throw await executionElement.functionData.fallbackFunction!(this.value);
                         }
                     }
                 }
@@ -260,15 +260,15 @@ export class Try<T> {
     }
 
 
-    public filter(predicateFunc: (value: T) => boolean | Promise<boolean>, throwbackFunction?: (value: T) => void): Try<T> {
+    public filter(predicateFunc: (value: T) => boolean | Promise<boolean>, throwbackFunction?: (value: T) => Error): Try<T> {
         this.executionStack.push({
             name: TryFunctions.FILTER,
-            functionData: {func: predicateFunc, fallbackFunction: throwbackFunction ?? ((value: any) => {throw new NoSuchElementException(`Predicate does not hold for ${value}`)}) },
+            functionData: {func: predicateFunc, fallbackFunction: throwbackFunction ?? ((value: T) => {throw new NoSuchElementException(`Predicate does not hold for ${value}`)}) },
             returning: false
         });
         return this;
     }
-    public filterNot(predicateFunc: (value: T) => boolean | Promise<boolean>, throwbackFunction?: (value: T) => void): Try<T> {
+    public filterNot(predicateFunc: (value: T) => boolean | Promise<boolean>, throwbackFunction?: (value: T) => Error): Try<T> {
         this.executionStack.push({
             name: TryFunctions.FILTERNOT,
             functionData: {func: predicateFunc, fallbackFunction: throwbackFunction ?? ((value: T) => {throw new NoSuchElementException(`Predicate does not hold for ${value}`)}) },

--- a/src/test/Try.test.ts
+++ b/src/test/Try.test.ts
@@ -202,6 +202,7 @@ describe("Try", () => {
     });
 
     describe("Try.filterNot", () => {
+
         test("filter should return Failure if predicate does not hold", async () => {
             const result = Try.success(2).filterNot(v => v > 2);
             await expect(result.get()).rejects.toThrow("Predicate does not hold for 2");
@@ -209,7 +210,7 @@ describe("Try", () => {
         });
 
         test("filter should throw custom exception if predicate does not hold", async () => {
-            const result = Try.success(2).filterNot(v => v > 2, v => { throw new Error("Custom Predicate does not hold for " + v) });
+            const result = Try.success(2).filterNot(v => v > 2, v => Error("Custom Predicate does not hold for " + v));
             await expect(result.get()).rejects.toThrow("Custom Predicate does not hold for 2");
             expect(result.isFailure()).toBe(true);
         });
@@ -230,7 +231,7 @@ describe("Try", () => {
         });
 
         test("filterNot should throw custom exception if predicate does not hold", async () => {
-            const result = Try.success(2).filter(v => v <= 2, v => { throw new Error("Custom Predicate does not hold for " + v) });
+            const result = Try.success(2).filter(v => v <= 2, v => Error("Custom Predicate does not hold for " + v));
             await expect(result.get()).rejects.toThrow("Custom Predicate does not hold for 2");
             expect(result.isFailure()).toBe(true);
         });


### PR DESCRIPTION
Because the filter function could have been used as a "runIf" function due to the return type of `void` this is a breaking change. The returned Error object (or a derived one) is now explicitly thrown. It is still possible to throw inside the function without violating the signature due to the fact that a throwing function will return `never` which is a bottom type of everything.